### PR TITLE
Start dockerizing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM golang:1.18.8-buster
+
+# Install deps
+RUN apt-get update && apt-get install -y \
+  libssl-dev \
+  ca-certificates \
+  fuse
+
+ENV KUBO_SRC_DIR /kubo
+ENV KUBO_CM_SRC_DIR /kubo-car-mirror
+
+# Download packages first so they can be cached.
+COPY kubo-car-mirror/go.mod kubo-car-mirror/go.sum $KUBO_CM_SRC_DIR/
+RUN cd $KUBO_CM_SRC_DIR \
+  && go mod download
+
+COPY kubo/go.mod kubo/go.sum $KUBO_SRC_DIR/
+RUN cd $KUBO_SRC_DIR \
+  && go mod download
+
+COPY kubo $KUBO_SRC_DIR
+COPY kubo-car-mirror $KUBO_CM_SRC_DIR
+
+RUN cd $KUBO_CM_SRC_DIR \
+  && make build
+
+# TODO...

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ build-plugin: setup-plugin
 
 build: build-core build-plugin
 
+build-docker:
+	cd .. && docker build -t kubo-car-mirror -f kubo-car-mirror/Dockerfile .
+
 test: test-unit sharness
 
 test-unit:


### PR DESCRIPTION
As requested by @b5.  I'm assuming we want an image that can accept `ipfs` and `carmirror` commands, where someone would run `ipfs daemon` in one container, and then `carmirror ...` commands in another attached to that container appropriately so the commands are relative to that ipfs instance / blockstore. 
