### PR TITLE
CLI changes

### DIFF
--- a/carmirror/carmirror.go
+++ b/carmirror/carmirror.go
@@ -256,7 +256,7 @@ func (cm *CarMirror) LsHandler() http.HandlerFunc {
 			log.Debugw("LsHandler", "params", p)
 			var sessions []string
 
-			// log.Debugw("LsHandler", "server.sinkSessions", cm.server.SinkSessions())
+			log.Debugw("LsHandler", "server.sinkSessions", cm.server.SinkSessions())
 			sessionTokens := cm.server.SinkSessions()
 			for _, sessionToken := range sessionTokens {
 				sessions = append(sessions, string(sessionToken))
@@ -286,7 +286,7 @@ func (cm *CarMirror) LsHandler() http.HandlerFunc {
 				log.Debugw("LsHandler", "sessionInfo", sessionInfo)
 			}
 
-			// log.Debugw("LsHandler", "client.sinkSessions", cm.client.SinkSessions())
+			log.Debugw("LsHandler", "client.sinkSessions", cm.client.SinkSessions())
 			// TODO: update client.SinkSessions to return a slice of session tokens instead of strings
 			clientSessionTokens := cm.client.SinkSessions()
 			for _, sessionToken := range clientSessionTokens {
@@ -302,7 +302,7 @@ func (cm *CarMirror) LsHandler() http.HandlerFunc {
 				log.Debugw("LsHandler", "sessionInfo", sessionInfo)
 			}
 
-			// log.Debugw("LsHandler", "client.sourceSessions", cm.client.SourceSessions())
+			log.Debugw("LsHandler", "client.sourceSessions", cm.client.SourceSessions())
 			clientSessionTokens = cm.client.SourceSessions()
 			for _, sessionToken := range clientSessionTokens {
 				sessions = append(sessions, string(sessionToken))

--- a/carmirror/carmirror_test.go
+++ b/carmirror/carmirror_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	cm "github.com/fission-codes/go-car-mirror/carmirror"
+	cm "github.com/fission-codes/go-car-mirror/core"
 	cmipld "github.com/fission-codes/go-car-mirror/ipld"
 	"golang.org/x/exp/slices"
 

--- a/carmirror/store.go
+++ b/carmirror/store.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	cm "github.com/fission-codes/go-car-mirror/carmirror"
+	cm "github.com/fission-codes/go-car-mirror/core"
 	errors "github.com/fission-codes/go-car-mirror/errors"
 	cmipld "github.com/fission-codes/go-car-mirror/ipld"
 	blocks "github.com/ipfs/go-block-format"

--- a/cmd/carmirror.go
+++ b/cmd/carmirror.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -13,31 +15,40 @@ var (
 	defaultCmdAddr = "http://localhost:2502"
 )
 
+const pushBackgroundOptionName = "background"
+const pullBackgroundOptionName = "background"
+
 var log = golog.Logger("kubo-car-mirror")
 
 // root command
 var root = &cobra.Command{
 	Use:   "carmirror",
-	Short: "carmirror is a tool for efficiently diffing, deduplicating, packaging, and transmitting IPLD data from a source node",
-	Long: `Requires an IPFS plugin. More details:
+	Short: "carmirror is a tool for efficiently diffing, deduplicating, packaging, and transmitting IPLD data from a source node to a sink node.",
+	Long: `Requires a Kubo plugin. More details:
 https://github.com/fission-codes/kubo-car-mirror`,
 }
 
 // push
-var push = &cobra.Command{
+var push *cobra.Command = &cobra.Command{
 	Use:   "push",
 	Short: "copy cid from local repo to remote addr",
 	Args:  cobra.RangeArgs(2, 3),
 	Run: func(cmd *cobra.Command, args []string) {
 		cid := args[0]
 		addr := args[1]
+		var background string
+		if cmd.Flag(pushBackgroundOptionName).Value.String() == "true" {
+			background = "true"
+		} else {
+			background = "false"
+		}
 
 		var endpoint string
 		if len(args) == 3 {
 			diff := args[2]
-			endpoint = fmt.Sprintf("push/new?cid=%s&addr=%s&diff=%s", cid, addr, diff)
+			endpoint = fmt.Sprintf("push/new?cid=%s&addr=%s&diff=%s&background=%s", cid, addr, diff, background)
 		} else {
-			endpoint = fmt.Sprintf("/push/new?cid=%s&addr=%s", cid, addr)
+			endpoint = fmt.Sprintf("/push/new?cid=%s&addr=%s&background=%s", cid, addr, background)
 		}
 
 		res, err := doRemoteHTTPReq("POST", endpoint)
@@ -45,6 +56,7 @@ var push = &cobra.Command{
 			fmt.Println(err.Error())
 			return
 		}
+
 		// TODO: proper response handling
 		fmt.Printf("pushed cid %s to:\n\t%s\n", cid, addr)
 		fmt.Printf("response = %s\n", res)
@@ -58,8 +70,14 @@ var pull = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cid := args[0]
 		addr := args[1]
+		var background string
+		if cmd.Flag(pullBackgroundOptionName).Value.String() == "true" {
+			background = "true"
+		} else {
+			background = "false"
+		}
 
-		endpoint := fmt.Sprintf("/pull/new?cid=%s&addr=%s", cid, addr)
+		endpoint := fmt.Sprintf("/pull/new?cid=%s&addr=%s&background=%s", cid, addr, background)
 		_, err := doRemoteHTTPReq("POST", endpoint)
 		if err != nil {
 			fmt.Println(err.Error())
@@ -70,9 +88,34 @@ var pull = &cobra.Command{
 	},
 }
 
+// ls
+var ls = &cobra.Command{
+	Use:   "ls",
+	Short: "list all active transfers",
+	Run: func(cmd *cobra.Command, args []string) {
+		endpoint := "/ls"
+		res, err := doRemoteHTTPReq("POST", endpoint)
+		if err != nil {
+			fmt.Println(err.Error())
+			return
+		}
+
+		var prettyJSON bytes.Buffer
+		err = json.Indent(&prettyJSON, []byte(res), "", "  ")
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		fmt.Printf("sessions:\n%s\n", prettyJSON.Bytes())
+	},
+}
+
 func init() {
 	root.PersistentFlags().StringVar(&defaultCmdAddr, "commands-address", defaultCmdAddr, "address to issue requests that control local carmirror")
-	root.AddCommand(push, pull)
+	push.Flags().BoolP(pushBackgroundOptionName, "b", false, "push in background")
+	pull.Flags().BoolP(pullBackgroundOptionName, "b", false, "pull in background")
+	root.AddCommand(push, pull, ls)
 }
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 )
 
 require (
-	github.com/fission-codes/go-car-mirror v0.0.0-20230103193822-cb40db094158
+	github.com/fission-codes/go-car-mirror v0.0.0-20230104200746-e85e5a0721dd
 	github.com/ipfs/kubo v0.17.0
 	github.com/spf13/cobra v1.6.1
 	github.com/zeebo/xxh3 v1.0.2

--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 )
 
 require (
-	github.com/fission-codes/go-car-mirror v0.0.0-20230104200746-e85e5a0721dd
+	github.com/fission-codes/go-car-mirror v0.0.0-20230105184911-ebc7012d082d
 	github.com/ipfs/kubo v0.17.0
 	github.com/spf13/cobra v1.6.1
 	github.com/zeebo/xxh3 v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -223,6 +223,8 @@ github.com/fission-codes/go-car-mirror v0.0.0-20230103193822-cb40db094158 h1:iGB
 github.com/fission-codes/go-car-mirror v0.0.0-20230103193822-cb40db094158/go.mod h1:YIWeUrae+ldUOXZ1c+ykUBBY449gHFP7T7W0tQYEVhE=
 github.com/fission-codes/go-car-mirror v0.0.0-20230104200746-e85e5a0721dd h1:2ccGU2bPrZTUAD4sCUOl3yon2wqHJH4tB01tTy13tn0=
 github.com/fission-codes/go-car-mirror v0.0.0-20230104200746-e85e5a0721dd/go.mod h1:YIWeUrae+ldUOXZ1c+ykUBBY449gHFP7T7W0tQYEVhE=
+github.com/fission-codes/go-car-mirror v0.0.0-20230105184911-ebc7012d082d h1:r6Xb0y1Lh9MXw3jAG0khLQMeW8ybdGzRI1p2dLpCYCg=
+github.com/fission-codes/go-car-mirror v0.0.0-20230105184911-ebc7012d082d/go.mod h1:YIWeUrae+ldUOXZ1c+ykUBBY449gHFP7T7W0tQYEVhE=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=
 github.com/flynn/noise v1.0.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwUTag=

--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,8 @@ github.com/fission-codes/go-bloom v0.0.0-20221130203706-f6093fcbce27 h1:V3xqbHs6
 github.com/fission-codes/go-bloom v0.0.0-20221130203706-f6093fcbce27/go.mod h1:qNZuJ550jblK67hi7N7l/ygJpVQqNTiy0IC2/NDQ8yo=
 github.com/fission-codes/go-car-mirror v0.0.0-20230103193822-cb40db094158 h1:iGBlWquC+vct74s7SCRNXerGCxPQFque7QG1v13fP68=
 github.com/fission-codes/go-car-mirror v0.0.0-20230103193822-cb40db094158/go.mod h1:YIWeUrae+ldUOXZ1c+ykUBBY449gHFP7T7W0tQYEVhE=
+github.com/fission-codes/go-car-mirror v0.0.0-20230104200746-e85e5a0721dd h1:2ccGU2bPrZTUAD4sCUOl3yon2wqHJH4tB01tTy13tn0=
+github.com/fission-codes/go-car-mirror v0.0.0-20230104200746-e85e5a0721dd/go.mod h1:YIWeUrae+ldUOXZ1c+ykUBBY449gHFP7T7W0tQYEVhE=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=
 github.com/flynn/noise v1.0.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwUTag=

--- a/test/sharness/t0000-car-mirror.sh
+++ b/test/sharness/t0000-car-mirror.sh
@@ -151,11 +151,6 @@ run_push_test() {
     carmirrori 0 push $ROOT_CID $(cm_cli_remote_addr 1)
   "
 
-  # sleep 5
-  
-  iptb logs 0
-  iptb logs 1
-
   check_has_cid_root 1 $ROOT_CID
 
   test_expect_success "shut down nodes" '
@@ -182,8 +177,7 @@ run_pull_test() {
     carmirrori 1 pull $ROOT_CID $(cm_cli_remote_addr 0)
   "
 
-  iptb logs 0
-  iptb logs 1
+  # sleep 5
 
   check_has_cid_root 1 $ROOT_CID
 

--- a/test/sharness/t0000-car-mirror.sh
+++ b/test/sharness/t0000-car-mirror.sh
@@ -131,7 +131,6 @@ check_not_has_cid_root() {
 ROOT_CID=QmWXCR7ZwcQpvzJA5fjkQMJTe2rwJgYUtoSxBXFZ3uBY1W
 
 # ROOT_CID=QmVQJMFnQ9vqoeF983FyURehB4iktkupfGjAGcvC5ivMNL
-
 run_push_test() {
   startup_cluster_disconnected 2 "$@"
 
@@ -148,8 +147,10 @@ run_push_test() {
   check_not_has_cid_root 1 $ROOT_CID
 
   test_expect_success "can push from node 0 to node 1" "
-    carmirrori 0 push $ROOT_CID $(cm_cli_remote_addr 1)
+    carmirrori 0 push -c $ROOT_CID -a $(cm_cli_remote_addr 1)
   "
+
+  sleep 5
 
   check_has_cid_root 1 $ROOT_CID
 
@@ -157,6 +158,65 @@ run_push_test() {
     iptb stop && iptb_wait_stop
   '
 }
+
+run_push_background_test() {
+  startup_cluster_disconnected 2 "$@"
+
+  test_expect_success "clean repo before test" '
+    ipfsi 0 repo gc > /dev/null &&
+    ipfsi 1 repo gc > /dev/null
+  '
+
+  test_expect_success "import test CAR file on node 0" '
+    ipfsi 0 dag import ../t0000-car-mirror-data/car-mirror.car
+  '
+
+  check_has_cid_root 0 $ROOT_CID
+  check_not_has_cid_root 1 $ROOT_CID
+
+  test_expect_success "can push from node 0 to node 1" "
+    carmirrori 0 push -b -c $ROOT_CID -a $(cm_cli_remote_addr 1)
+  "
+
+  check_not_has_cid_root 1 $ROOT_CID
+
+  test_expect_success "before: carmirror ls on node 0 is not blank" "
+    carmirrori 0 ls 2> get_error
+    cat get_error
+  "
+  test_expect_success "before: carmirror ls on node 1 is not blank" "
+    carmirrori 1 ls 2> get_error
+    cat get_error
+  "
+
+  iptb logs 0 2>&1 > get_error
+  cat get_error
+  iptb logs 1 2>&1 > get_error
+  cat get_error
+
+  sleep 5
+
+  test_expect_success "after: carmirror ls on node 0 is not blank" "
+    carmirrori 0 ls 2> get_error
+    cat get_error
+  "
+  test_expect_success "after: carmirror ls on node 1 is not blank" "
+    carmirrori 1 ls 2> get_error
+    cat get_error
+  "
+
+  iptb logs 0 2>&1 > get_error
+  cat get_error
+  iptb logs 1 2>&1 > get_error
+  cat get_error
+
+  check_has_cid_root 1 $ROOT_CID
+
+  test_expect_success "shut down nodes" '
+    iptb stop && iptb_wait_stop
+  '
+}
+
 
 run_pull_test() {
   startup_cluster_disconnected 2 "$@"
@@ -174,10 +234,8 @@ run_pull_test() {
   check_not_has_cid_root 1 $ROOT_CID
 
   test_expect_success "can pull from node 0 to node 1" "
-    carmirrori 1 pull $ROOT_CID $(cm_cli_remote_addr 0)
+    carmirrori 1 pull -c $ROOT_CID -a $(cm_cli_remote_addr 0)
   "
-
-  # sleep 5
 
   check_has_cid_root 1 $ROOT_CID
 
@@ -195,6 +253,7 @@ test_expect_success "configure the plugin" '
 '
 
 run_push_test
+run_push_background_test
 run_pull_test
 
 test_done


### PR DESCRIPTION
- core package rename and go-car-mirror updates
- Background option for push and pull, defaults to false
- No more positional CLI args, to avoid brittle code
- Initial messy work on ls command, but most definitely will change as we figure out where we get the list of all sessions, even those not active, meaning those that have any cache or stats still present