### PR TITLE
Making kubo-car-mirror from kubo without sibling repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,17 +30,13 @@ setup-plugin:
 	cd ../kubo && go get -d github.com/fission-codes/kubo-car-mirror
 	cd ../kubo && go mod tidy
 
-setup-plugin-from-github:
-	grep -v carmirror ../kubo/plugin/loader/preload_list > ../kubo/plugin/loader/preload_list.tmp
-	echo "" >> ../kubo/plugin/loader/preload_list.tmp
-	echo "carmirror github.com/fission-codes/kubo-car-mirror/plugin *" >> ../kubo/plugin/loader/preload_list.tmp
-	mv ../kubo/plugin/loader/preload_list.tmp ../kubo/plugin/loader/preload_list
-	$(MAKE) -C ../kubo plugin/loader/preload.go
-	cd ../kubo && go get -d github.com/fission-codes/kubo-car-mirror
-	cd ../kubo && go mod tidy
-	cd ../kubo && go get github.com/fission-codes/kubo-car-mirror/cmd/carmirror@$(KUBO_CAR_MIRROR_GIT_VERSION)
-	cd ../kubo && GOBIN=$(PWD)/../kubo/cmd/carmirror go install github.com/fission-codes/kubo-car-mirror/cmd/carmirror@$(KUBO_CAR_MIRROR_GIT_VERSION)
-	echo "Kubo now includes kubo-car-mirror.  Review changes and commit in the kubo repository."
+setup-kubo-build:
+	cp -R build/carmirror ../kubo/carmirror
+	echo "" >> ../kubo/Makefile
+	echo "build-carmirror:" >> ../kubo/Makefile
+	echo "	@gmake $@" >> ../kubo/Makefile
+	echo "" >> ../kubo/GNUmakefile
+	echo "include carmirror/Rules.mk" >> ../kubo/GNUmakefile
 
 build-plugin: setup-plugin
 	$(MAKE) -C ../kubo build

--- a/build/carmirror/Rules.mk
+++ b/build/carmirror/Rules.mk
@@ -1,0 +1,16 @@
+include mk/header.mk
+
+KUBO_CAR_MIRROR_GIT_VERSION ?= $(shell git ls-remote --refs --heads https://github.com/fission-codes/kubo-car-mirror.git main | awk '{print $$1}')
+
+build-carmirror:
+	grep -v carmirror plugin/loader/preload_list > plugin/loader/preload_list.tmp
+	echo "" >> plugin/loader/preload_list.tmp
+	echo "carmirror github.com/fission-codes/kubo-car-mirror/plugin *" >> plugin/loader/preload_list.tmp
+	mv plugin/loader/preload_list.tmp plugin/loader/preload_list
+	$(MAKE) plugin/loader/preload.go
+	go get -d github.com/fission-codes/kubo-car-mirror@$(KUBO_CAR_MIRROR_GIT_VERSION)
+	go mod tidy
+	go get github.com/fission-codes/kubo-car-mirror/cmd/carmirror@$(KUBO_CAR_MIRROR_GIT_VERSION)
+	GOBIN=$(PWD)/carmirror/cmd/carmirror go install github.com/fission-codes/kubo-car-mirror/cmd/carmirror@$(KUBO_CAR_MIRROR_GIT_VERSION)
+
+include mk/footer.mk

--- a/build/carmirror/cmd/carmirror/.gitignore
+++ b/build/carmirror/cmd/carmirror/.gitignore
@@ -1,0 +1,2 @@
+carmirror
+carmirror.exe


### PR DESCRIPTION
Add setup-kubo-build target, for setting up a kubo make target that builds and installs the binary without a sibling repo
