### PR TITLE
Push and pull work now

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu"]
-        go: ["1.18.x"]
+        go: ["1.19.x"]
     env:
       COVERAGES: ""
     runs-on: ${{ matrix.os }}-latest
@@ -38,5 +38,5 @@ jobs:
         run: make test-unit
       - name: Check formatted
         run: gofmt -l .
-      # - name: Run sharness tests
-      #   run: make sharness-v
+      - name: Run sharness tests
+        run: make sharness-v

--- a/cmd/carmirror/carmirror.go
+++ b/cmd/carmirror/carmirror.go
@@ -114,30 +114,6 @@ var ls = &cobra.Command{
 	},
 }
 
-var close = &cobra.Command{
-	Use:   "close",
-	Short: "closes the client session",
-	Run: func(cmd *cobra.Command, args []string) {
-		endpoint := fmt.Sprintf("/close?session=%s", session)
-		res, err := doRemoteHTTPReq("POST", endpoint)
-		if err != nil {
-			fmt.Println(err.Error())
-			return
-		}
-
-		log.Debugf("response: %s\n", res)
-
-		var prettyJSON bytes.Buffer
-		err = json.Indent(&prettyJSON, []byte(res), "", "  ")
-		if err != nil {
-			fmt.Println(err)
-			return
-		}
-
-		fmt.Printf("response:\n%s\n", prettyJSON.Bytes())
-	},
-}
-
 var cancel = &cobra.Command{
 	Use:   "cancel",
 	Short: "cancels the client session",
@@ -202,15 +178,12 @@ func init() {
 	pull.MarkFlagRequired("cid")
 	pull.MarkFlagRequired("addr")
 
-	close.Flags().StringVarP(&session, "session", "s", "", "session id to close")
-	close.MarkFlagRequired("session")
-
 	cancel.Flags().StringVarP(&session, "session", "s", "", "session id to cancel")
 	cancel.MarkFlagRequired("session")
 
 	stats.Flags().StringVarP(&session, "session", "s", "", "session id to display stats for")
 
-	root.AddCommand(push, pull, ls, close, stats, cancel)
+	root.AddCommand(push, pull, ls, stats, cancel)
 }
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -227,3 +227,5 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	lukechampine.com/blake3 v1.1.7 // indirect
 )
+
+replace github.com/fission-codes/go-car-mirror => ../go-car-mirror

--- a/go.mod
+++ b/go.mod
@@ -227,5 +227,3 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	lukechampine.com/blake3 v1.1.7 // indirect
 )
-
-replace github.com/fission-codes/go-car-mirror => ../go-car-mirror

--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 )
 
 require (
-	github.com/fission-codes/go-car-mirror v0.0.0-20230209183945-ad1c811456fb
+	github.com/fission-codes/go-car-mirror v0.0.0-20230308173918-a8b2e88c3e71
 	github.com/ipfs/kubo v0.17.0
 	github.com/spf13/cobra v1.6.1
 	github.com/zeebo/xxh3 v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -245,6 +245,8 @@ github.com/fission-codes/go-car-mirror v0.0.0-20230126145128-6923725a9c81 h1:+rx
 github.com/fission-codes/go-car-mirror v0.0.0-20230126145128-6923725a9c81/go.mod h1:YIWeUrae+ldUOXZ1c+ykUBBY449gHFP7T7W0tQYEVhE=
 github.com/fission-codes/go-car-mirror v0.0.0-20230209183945-ad1c811456fb h1:fqcF8BkjpEcQ7G6vynNuRsrW93cSS5Owojs3wfTyNq4=
 github.com/fission-codes/go-car-mirror v0.0.0-20230209183945-ad1c811456fb/go.mod h1:YIWeUrae+ldUOXZ1c+ykUBBY449gHFP7T7W0tQYEVhE=
+github.com/fission-codes/go-car-mirror v0.0.0-20230308173918-a8b2e88c3e71 h1:kxcOs1XiHgZoFAHnh03p7m7zyz9YucU/cnNdiUvci0w=
+github.com/fission-codes/go-car-mirror v0.0.0-20230308173918-a8b2e88c3e71/go.mod h1:YIWeUrae+ldUOXZ1c+ykUBBY449gHFP7T7W0tQYEVhE=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=
 github.com/flynn/noise v1.0.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwUTag=

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -102,7 +102,6 @@ func (p *CarMirrorPlugin) listenLocalCommands() error {
 	m.Handle("/push/new", p.carmirror.NewPushSessionHandler())
 	m.Handle("/pull/new", p.carmirror.NewPullSessionHandler())
 	m.Handle("/ls", p.carmirror.LsHandler())
-	m.Handle("/close", p.carmirror.CloseHandler())
 	m.Handle("/cancel", p.carmirror.CancelHandler())
 	m.Handle("/stats", p.carmirror.StatsHandler())
 	return http.ListenAndServe(p.HTTPCommandsAddr, m)


### PR DESCRIPTION
- Update to latest go-car-mirror where both push and pull work over http.
- Remove close command, since there's no longer a close a session concept.
- Switch to Go 1.19.